### PR TITLE
Fix: TokenRequest

### DIFF
--- a/edge/pkg/metamanager/client/serviceaccount.go
+++ b/edge/pkg/metamanager/client/serviceaccount.go
@@ -102,15 +102,6 @@ func getTokenLocally(name, namespace string, tr *authenticationv1.TokenRequest) 
 		klog.Errorf("unmarshal resource %s token request failed: %v", resKey, err)
 		return nil, err
 	}
-	if requiresRefresh(&tokenRequest) {
-		err := dao.DeleteMetaByKey(resKey)
-		if err != nil {
-			klog.Errorf("delete meta %s failed: %v", resKey, err)
-			return nil, err
-		}
-		klog.Errorf("resource %s token expired", resKey)
-		return nil, fmt.Errorf("resource %s token expired", resKey)
-	}
 	return &tokenRequest, nil
 }
 
@@ -135,12 +126,27 @@ func getTokenRemotely(resource string, tr *authenticationv1.TokenRequest, c *ser
 }
 
 func (c *serviceAccountToken) GetServiceAccountToken(namespace string, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
-	tokenReq, err := getTokenLocally(name, namespace, tr)
+	localTokenReq, err := getTokenLocally(name, namespace, tr)
 	if err != nil {
 		resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypeServiceAccountToken, name)
 		return getTokenRemotely(resource, tr, c)
 	}
-	return tokenReq, nil
+	if requiresRefresh(localTokenReq) {
+		resKey := metamanager.KeyFunc(name, namespace, tr)
+		resource := fmt.Sprintf("%s/%s/%s", namespace, model.ResourceTypeServiceAccountToken, name)
+		remoteTokenReq, err := getTokenRemotely(resource, tr, c)
+		if err != nil {
+			klog.Errorf(", err: %v", fmt.Errorf("get remotel service account token failed, return expiration token"))
+			return localTokenReq, nil
+		}
+		err = dao.DeleteMetaByKey(resKey)
+		if err != nil {
+			klog.Errorf("delete meta %s failed: %v", resKey, err)
+			return nil, err
+		}
+		return remoteTokenReq, nil
+	}
+	return localTokenReq, nil
 }
 
 func handleServiceAccountTokenFromMetaDB(content []byte) (*authenticationv1.TokenRequest, error) {


### PR DESCRIPTION
In the original getTokenLocally logic of version 1.13:

Retrieve the token locally.
If the token is expired, delete the token from the local cache.
If an error is detected, fetch the token from the cloud, completing the token refresh process.
In this logic, if there is a network outage and the token is expired, the token will be deleted from the local cache, but it cannot be fetched from the cloud, causing the Pod to fail to start.

Therefore, I made the following changes:

Moved the expiration logic out of getTokenLocally.
The expired token will only be deleted if getTokenRemotely is successful.
In case getTokenRemotely fails, return the expired token.