### PR TITLE
feat: change certificate CommonName validation from exact match to pr…

### DIFF
--- a/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
@@ -106,7 +106,7 @@ func verifyCertSubject(cert *x509.Certificate, nodeName string) error {
 		return nil
 	}
 	commonName := fmt.Sprintf("system:node:%s", nodeName)
-	if cert.Subject.Organization[0] == "system:nodes" && cert.Subject.CommonName == commonName {
+	if cert.Subject.Organization[0] == "system:nodes" && strings.HasPrefix(cert.Subject.CommonName, commonName) {
 		return nil
 	}
 	return fmt.Errorf("request node name is not match with the certificate")

--- a/edge/pkg/edgehub/certificate/certmanager.go
+++ b/edge/pkg/edgehub/certificate/certmanager.go
@@ -5,6 +5,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -40,6 +42,10 @@ var jitteryDuration = func(totalDuration float64) time.Duration {
 }
 
 var CleanupTokenChan = make(chan struct{}, 1)
+
+const (
+	DefaultClusterName = "default-cluster"
+)
 
 type CertManager struct {
 	RotateCertificates bool
@@ -100,7 +106,7 @@ func (cm *CertManager) getCurrent() (*tls.Certificate, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse certificate data: %v", err)
 	}
-	if cn := certs[0].Subject.CommonName; cn != fmt.Sprintf("system:node:%s", cm.NodeName) {
+	if cn := certs[0].Subject.CommonName; !strings.HasPrefix(cn, fmt.Sprintf("system:node:%s", cm.NodeName)) {
 		return nil, fmt.Errorf("certificate CN %s does not match node name %s", cn, cm.NodeName)
 	}
 	cert.Leaf = certs[0]
@@ -277,12 +283,19 @@ func (cm *CertManager) GetEdgeCert(url string, capem []byte, tlscert tls.Certifi
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate a private key of edge cert, err: %v", err)
 	}
+	clusterName := ""
+	if token != "" {
+		clusterName = getClusterNameFromToken(token)
+	} else {
+		clusterName = getClusterNameFromTLSCert(tlscert)
+	}
+
 	csrPem, err := h.CreateCSR(pkix.Name{
 		Country:      []string{"CN"},
 		Organization: []string{"system:nodes"},
 		//Locality:     []string{"Hangzhou"},
 		//Province:     []string{"Zhejiang"},
-		CommonName: fmt.Sprintf("system:node:%s", cm.NodeName),
+		CommonName: fmt.Sprintf("system:node:%s.%s", cm.NodeName, clusterName),
 	}, pkw, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create a csr of edge cert, err %v", err)
@@ -312,4 +325,70 @@ func (cm *CertManager) GetEdgeCert(url string, capem []byte, tlscert tls.Certifi
 		return nil, nil, fmt.Errorf("failed to call http, code: %d, message: %s", res.StatusCode, string(content))
 	}
 	return content, pkw.DER(), nil
+}
+
+// getClusterNameFromToken extracts cluster name from JWT token header
+func getClusterNameFromToken(token string) string {
+	if token == "" {
+		return DefaultClusterName
+	}
+
+	// JWT token format: header.payload.signature
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return DefaultClusterName
+	}
+
+	// Parse header part
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return DefaultClusterName
+	}
+
+	var header struct {
+		ClusterName string `json:"clustername"`
+	}
+
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return DefaultClusterName
+	}
+
+	if header.ClusterName == "" {
+		return DefaultClusterName
+	}
+
+	return header.ClusterName
+}
+
+// getClusterNameFromTLSCert extracts cluster name from TLS certificate
+func getClusterNameFromTLSCert(tlscert tls.Certificate) string {
+	if len(tlscert.Certificate) == 0 {
+		klog.Warning("TLS certificate is empty, returning default cluster name")
+		return DefaultClusterName
+	}
+
+	// Parse the first certificate in the chain
+	cert, err := x509.ParseCertificate(tlscert.Certificate[0])
+	if err != nil {
+		klog.Errorf("Failed to parse TLS certificate: %v", err)
+		return DefaultClusterName
+	}
+
+	// Try to extract cluster name from DNS names (SAN extension)
+	if len(cert.DNSNames) > 0 {
+		// Use the first DNS name as cluster name
+		clusterName := cert.DNSNames[0]
+		klog.V(4).Infof("Extracted cluster name from certificate DNS names: %s", clusterName)
+		return clusterName
+	}
+
+	// Fallback to CommonName if no DNS names
+	if cert.Subject.CommonName != "" {
+		clusterName := cert.Subject.CommonName
+		klog.V(4).Infof("Extracted cluster name from certificate CommonName: %s", clusterName)
+		return clusterName
+	}
+
+	klog.Warning("No cluster name found in TLS certificate, returning default cluster name")
+	return DefaultClusterName
 }


### PR DESCRIPTION
…efix match

- Update cloud/pkg/cloudhub/servers/httpserver/certificate/certs.go
  - Change CommonName validation from exact match to startsWith match
  - Use strings.HasPrefix for more flexible certificate validation

- Update edge/pkg/edgehub/certificate/certmanager.go
  - Change CommonName validation from exact match to startsWith match
  - Improve certificate validation flexibility for edge nodes

This change allows certificates with CommonName starting with 'system:node:' to be accepted, rather than requiring exact match with specific node names. This provides better compatibility and flexibility for certificate management in KubeEdge deployments.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
