### PR TITLE
feat: enable EdgeStream and set NodeStatusMaxImages to 50

### DIFF
--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/default.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/default.go
@@ -147,7 +147,7 @@ func NewDefaultEdgeCoreConfig() (config *EdgeCoreConfig) {
 				Enable: false,
 			},
 			EdgeStream: &EdgeStream{
-				Enable:                  false,
+				Enable:                  true,
 				TLSTunnelCAFile:         constants.DefaultCAFile,
 				TLSTunnelCertFile:       constants.DefaultCertFile,
 				TLSTunnelPrivateKeyFile: constants.DefaultKeyFile,

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/default_kubelet_configuration.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/edgecore/v1alpha2/default_kubelet_configuration.go
@@ -73,7 +73,7 @@ func SetDefaultsKubeletConfiguration(obj *TailoredKubeletConfiguration) {
 	// default nil or negative value to -1 (implies node allocatable pid limit)
 	obj.PodPidsLimit = utilpointer.Int64(-1)
 	obj.CPUCFSQuotaPeriod = &metav1.Duration{Duration: 100 * time.Millisecond}
-	obj.NodeStatusMaxImages = utilpointer.Int32(0)
+	obj.NodeStatusMaxImages = utilpointer.Int32(50)
 	obj.MaxOpenFiles = 1000000
 	obj.ContentType = "application/json"
 	obj.SerializeImagePulls = utilpointer.Bool(true)


### PR DESCRIPTION
- Enable EdgeStream for improved edge-cloud communication
- Configure NodeStatusMaxImages to 50 for better image status reporting

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
