### PR TITLE
feat: add dynamic stream server certificate generation

### DIFF
--- a/cloud/pkg/cloudstream/certutil.go
+++ b/cloud/pkg/cloudstream/certutil.go
@@ -1,0 +1,123 @@
+package cloudstream
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"net"
+	"time"
+
+	pkgutil "github.com/kubeedge/kubeedge/pkg/util"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/klog/v2"
+)
+
+// Copy from edgewize
+
+func SignCloudCoreCert(cacrt, cakey []byte) ([]byte, []byte, error) {
+	podIP, err := pkgutil.GetLocalIP(pkgutil.GetHostname())
+	if err != nil {
+		klog.Errorf("Failed to get Local IP address: %v", err)
+		return nil, nil, err
+	}
+	klog.Infoln("pod ip", podIP)
+
+	cfg := &certutil.Config{
+		CommonName:   "EdgeWize",
+		Organization: []string{"EdgeWize"},
+		Usages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+		},
+		AltNames: certutil.AltNames{
+			IPs: []net.IP{net.ParseIP(podIP)}, // TODO
+		},
+	}
+	var keyDER []byte
+	caCert, err := x509.ParseCertificate(cacrt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse a caCert from the given ASN.1 DER data, err: %v", err)
+	}
+	serverKey, err := NewPrivateKey(caCert.SignatureAlgorithm)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate a privateKey, err: %v", err)
+	}
+	var caKey crypto.Signer
+	switch caCert.SignatureAlgorithm {
+	case x509.ECDSAWithSHA256:
+		caKey, err = x509.ParseECPrivateKey(cakey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse ECPrivateKey, err: %v", err)
+		}
+		keyDER, err = x509.MarshalECPrivateKey(serverKey.(*ecdsa.PrivateKey))
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert an EC private key to SEC 1, ASN.1 DER form, err: %v", err)
+		}
+	case x509.SHA256WithRSA:
+		caKey, err = x509.ParsePKCS1PrivateKey(cakey)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse PKCS1PrivateKey, err: %v", err)
+		}
+		keyDER = x509.MarshalPKCS1PrivateKey(serverKey.(*rsa.PrivateKey))
+	default:
+		return nil, nil, fmt.Errorf("unsupport signature algorithm: %s", caCert.SignatureAlgorithm.String())
+	}
+
+	certDER, err := NewCertFromCa(cfg, caCert, serverKey.Public(), caKey, 365*100)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate a certificate using the given CA certificate and key, err: %v", err)
+	}
+	return certDER, keyDER, nil
+}
+
+// NewPrivateKey creates a private key
+func NewPrivateKey(algorithm x509.SignatureAlgorithm) (crypto.Signer, error) {
+	switch algorithm {
+	case x509.ECDSAWithSHA256:
+		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case x509.SHA256WithRSA:
+		return rsa.GenerateKey(rand.Reader, 2048)
+	default:
+		return nil, fmt.Errorf("unsepport signature algorithm: %s", algorithm.String())
+	}
+}
+
+// NewCertFromCa creates a signed certificate using the given CA certificate and key
+func NewCertFromCa(cfg *certutil.Config, caCert *x509.Certificate, serverKey crypto.PublicKey, caKey crypto.Signer, validalityPeriod time.Duration) ([]byte, error) {
+	serial, err := rand.Int(rand.Reader, new(big.Int).SetInt64(math.MaxInt64))
+	if err != nil {
+		return nil, err
+	}
+	if len(cfg.CommonName) == 0 {
+		return nil, errors.New("must specify a CommonName")
+	}
+	if len(cfg.Usages) == 0 {
+		return nil, errors.New("must specify at least one ExtKeyUsage")
+	}
+
+	certTmpl := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:   cfg.CommonName,
+			Organization: cfg.Organization,
+		},
+		DNSNames:     cfg.AltNames.DNSNames,
+		IPAddresses:  cfg.AltNames.IPs,
+		SerialNumber: serial,
+		NotBefore:    time.Now().UTC(),
+		NotAfter:     time.Now().Add(time.Hour * 24 * validalityPeriod),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  cfg.Usages,
+	}
+	certDERBytes, err := x509.CreateCertificate(rand.Reader, &certTmpl, caCert, serverKey, caKey)
+	if err != nil {
+		return nil, err
+	}
+	return certDERBytes, nil
+}

--- a/cloud/pkg/cloudstream/streamserver.go
+++ b/cloud/pkg/cloudstream/streamserver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"os"
@@ -35,6 +36,17 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/client"
 	"github.com/kubeedge/kubeedge/common/constants"
 	"github.com/kubeedge/kubeedge/pkg/stream/flushwriter"
+)
+
+const (
+	// Stream server constants
+	StreamCertFile = "/etc/kubeedge-stream.crt"
+	StreamKeyFile  = "/etc/kubeedge-stream.key"
+	CertFileMode   = 0644
+
+	// Certificate constants
+	CertificateBlockType = "CERTIFICATE"
+	PrivateKeyBlockType  = "PRIVATE KEY"
 )
 
 type StreamServer struct {
@@ -404,10 +416,100 @@ func (s *StreamServer) Start() {
 			MinVersion: tls.VersionTLS12,
 		},
 	}
+
+	streamCertFile := StreamCertFile
+	streamKeyFile := StreamKeyFile
+	err = s.initStreamCert(streamCertFile, streamKeyFile)
+	if err != nil {
+		klog.Exitf("Init stream cert error %v", err)
+		return
+	}
+
 	klog.Infof("Prepare to start stream server ...")
-	err = streamServer.ListenAndServeTLS(config.Config.TLSStreamCertFile, config.Config.TLSStreamPrivateKeyFile)
+	err = streamServer.ListenAndServeTLS(streamCertFile, streamKeyFile)
 	if err != nil {
 		klog.Exitf("Start stream server error %v\n", err)
 		return
 	}
+}
+
+// initStreamCert reads the CA certificate and key from the cloudcore secret,
+// generates a new server certificate, and writes it to the specified files
+func (s *StreamServer) initStreamCert(streamCertFile, streamKeyFile string) error {
+	// Get CA certificate and key from cloudcore secret in kubeedge namespace
+	caCrt, caKey, err := s.getCACertificateAndKey()
+	if err != nil {
+		return fmt.Errorf("failed to get CA certificate and key: %v", err)
+	}
+
+	// Generate server certificate using the CA
+	serverCrt, serverKey, err := SignCloudCoreCert(caCrt, caKey)
+	if err != nil {
+		return fmt.Errorf("failed to generate server certificate: %v", err)
+	}
+
+	// Write certificate and key to files
+	if err := s.writeCertificateFiles(streamCertFile, streamKeyFile, serverCrt, serverKey); err != nil {
+		return fmt.Errorf("failed to write certificate files: %v", err)
+	}
+
+	return nil
+}
+
+// getCACertificateAndKey retrieves the CA certificate and key from the cloudcore secret
+func (s *StreamServer) getCACertificateAndKey() ([]byte, []byte, error) {
+	kubeClient := client.GetKubeClient()
+	if kubeClient == nil {
+		return nil, nil, fmt.Errorf("can not get kube client")
+	}
+
+	cloudhubSecret, err := kubeClient.CoreV1().Secrets("kubeedge").Get(context.Background(), "cloudcore", v1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("get ca secret error: %v", err)
+	}
+
+	caCrt, err := s.extractPEMData(cloudhubSecret.Data["tlsCA.crt"], "root ca cert")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caKey, err := s.extractPEMData(cloudhubSecret.Data["tlsCA.key"], "root ca key")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return caCrt, caKey, nil
+}
+
+// extractPEMData extracts and decodes PEM data from secret
+func (s *StreamServer) extractPEMData(data []byte, dataType string) ([]byte, error) {
+	if data == nil {
+		return nil, fmt.Errorf("secret %s is missing", dataType)
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM data for %s", dataType)
+	}
+
+	return block.Bytes, nil
+}
+
+// writeCertificateFiles writes the certificate and key to the specified files
+func (s *StreamServer) writeCertificateFiles(certFile, keyFile string, cert, key []byte) error {
+	certPem := pem.EncodeToMemory(&pem.Block{Type: CertificateBlockType, Bytes: cert})
+	keyPem := pem.EncodeToMemory(&pem.Block{Type: PrivateKeyBlockType, Bytes: key})
+
+	klog.V(3).Infof("server crt: %s", string(certPem))
+	klog.V(3).Infof("server key: %s", string(keyPem))
+
+	if err := os.WriteFile(certFile, certPem, CertFileMode); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(keyFile, keyPem, CertFileMode); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
- Generate stream server certs from cloudcore CA at runtime
- Remove hardcoded certificate file paths
- Extract CA credentials from kubeedge secret

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
