### PR TITLE
Feat/saa sync reconnect and resync (#30)

### DIFF
--- a/cloud/cmd/cloudcore/app/server.go
+++ b/cloud/cmd/cloudcore/app/server.go
@@ -51,6 +51,7 @@ import (
 	"github.com/kubeedge/kubeedge/cloud/pkg/dynamiccontroller"
 	"github.com/kubeedge/kubeedge/cloud/pkg/edgecontroller"
 	"github.com/kubeedge/kubeedge/cloud/pkg/policycontroller"
+	policypkg "github.com/kubeedge/kubeedge/cloud/pkg/policycontroller/config"
 	"github.com/kubeedge/kubeedge/cloud/pkg/router"
 	"github.com/kubeedge/kubeedge/cloud/pkg/synccontroller"
 	"github.com/kubeedge/kubeedge/cloud/pkg/taskmanager"
@@ -124,6 +125,8 @@ kubernetes controller which manages devices so that the device metadata/status d
 			gis := informers.GetInformersManager()
 
 			registerModules(config)
+			// init policycontroller config for later usage
+			policypkg.InitConfigure(config.Modules.PolicyController)
 
 			if config.Modules.IptablesManager == nil || config.Modules.IptablesManager.Enable && config.Modules.IptablesManager.Mode == v1alpha1.InternalMode {
 				// By default, IptablesManager manages tunnel port related iptables rules

--- a/cloud/pkg/cloudhub/authorization/resource_attributes.go
+++ b/cloud/pkg/cloudhub/authorization/resource_attributes.go
@@ -92,6 +92,9 @@ func isKubeedgeResourceMessage(router beehivemodel.MessageRoute) bool {
 	switch resourceType {
 	case beehivemodel.ResourceTypeRuleStatus:
 		return true
+	case beehivemodel.ResourceTypeSaAccess:
+		// Treat serviceaccountaccess as kubeedge non-resource for custom sync APIs
+		return true
 	}
 	// kubeedge allows node to update a list of pod status
 	if resourceType == beehivemodel.ResourceTypePodStatus && resourceName == "" {

--- a/cloud/pkg/policycontroller/config/config.go
+++ b/cloud/pkg/policycontroller/config/config.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"sync"
+
+	v1alpha1 "github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1"
+)
+
+var (
+	Config Configure
+	once   sync.Once
+)
+
+type Configure struct {
+	v1alpha1.PolicyController
+}
+
+func InitConfigure(pc *v1alpha1.PolicyController) {
+	if pc == nil {
+		// keep zero value defaults if not provided
+		return
+	}
+	once.Do(func() {
+		Config = Configure{
+			PolicyController: *pc,
+		}
+	})
+}

--- a/cloud/pkg/policycontroller/manager/reconcile.go
+++ b/cloud/pkg/policycontroller/manager/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -20,6 +21,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -49,6 +51,50 @@ func (c *Controller) Reconcile(ctx context.Context, request controllerruntime.Re
 		return controllerruntime.Result{}, nil
 	}
 	return c.syncRules(ctx, acc)
+}
+
+// HandleSyncRequest handles edge-initiated sync request, and sends back the list
+// of ServiceAccountAccess that should be present on that node.
+// The request message's resource is formatted as:
+//
+//	node/<nodeName>/<namespace or _>/serviceaccountaccess
+//
+// If namespace is "_", it means all namespaces.
+func (c *Controller) HandleSyncRequest(ctx context.Context, nodeName, namespace string) {
+	start := time.Now()
+	klog.V(2).Infof("[SAA SyncRequest] start: node=%s namespace=%q", nodeName, namespace)
+	list := &policyv1alpha1.ServiceAccountAccessList{}
+	var listOpts []client.ListOption
+	if namespace != "" && namespace != "_" {
+		listOpts = append(listOpts, &client.ListOptions{Namespace: namespace})
+	}
+	if err := c.Client.List(ctx, list, listOpts...); err != nil {
+		klog.Errorf("failed to list serviceaccountaccess for sync request: %v", err)
+		return
+	}
+	// filter by target node list
+	for i := range list.Items {
+		acc := &list.Items[i]
+		if acc.GetDeletionTimestamp() != nil {
+			klog.V(5).Infof("[SAA SyncRequest] skip deleting %s/%s", acc.Namespace, acc.Name)
+			continue
+		}
+		nodes, err := getNodeListOfServiceAccountAccess(ctx, c.Client, acc)
+		if err != nil {
+			klog.Errorf("failed to get nodes for %s/%s: %v", acc.Namespace, acc.Name, err)
+			continue
+		}
+		klog.V(4).Infof("[SAA SyncRequest] %s/%s targets=%v", acc.Namespace, acc.Name, nodes)
+		// if this node should hold this access, send it
+		for _, n := range nodes {
+			if n == nodeName {
+				klog.V(3).Infof("[SAA SyncRequest] send acc %s/%s to node=%s", acc.Namespace, acc.Name, nodeName)
+				c.send2Edge(acc, []string{nodeName}, model.UpdateOperation)
+				break
+			}
+		}
+	}
+	klog.V(2).Infof("[SAA SyncRequest] done: node=%s namespace=%q cost=%s", nodeName, namespace, time.Since(start))
 }
 
 func (c *Controller) filterResource(ctx context.Context, object client.Object) bool {
@@ -187,11 +233,8 @@ func (c *Controller) mapObjectFunc(_ context.Context, object client.Object) []co
 		sa := obj.Spec.ServiceAccountName
 		for _, am := range accList.Items {
 			if am.Spec.ServiceAccount.Name == sa && am.Spec.ServiceAccount.Namespace == object.GetNamespace() {
-				if obj.GetDeletionTimestamp() == nil {
-					// won't reconcile pod update event
-					return []controllerruntime.Request{}
-				}
-				klog.V(4).Infof("reconcile pod deleting %s/%s", obj.Namespace, obj.Name)
+				// Only pod create/delete events enter here (normal updates are filtered by predicates), immediately trigger a reconcile for the corresponding SAA
+				klog.V(4).Infof("enqueue SAA reconcile for pod event %s/%s", obj.Namespace, obj.Name)
 				return []controllerruntime.Request{{NamespacedName: client.ObjectKey{Namespace: am.Namespace, Name: am.Name}}}
 			}
 		}
@@ -225,6 +268,7 @@ func (c *Controller) filterObject(ctx context.Context, object client.Object) boo
 	case *corev1.Pod:
 		node := obj.Spec.NodeName
 		if obj.Spec.ServiceAccountName == "" || node == "" || !isEdgeNode(ctx, c.Client, node) {
+			klog.V(2).Infof("filter out pod %s/%s, node=%s", obj.Namespace, obj.Name, node)
 			return false
 		}
 		return true
@@ -268,9 +312,35 @@ func (c *Controller) SetupWithManager(ctx context.Context, mgr controllerruntime
 		Watches(&corev1.ServiceAccount{}, handler.EnqueueRequestsFromMapFunc(c.mapObjectFunc), builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			return c.filterObject(ctx, object)
 		}))).
-		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(c.mapObjectFunc), builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			return c.filterObject(ctx, object)
-		}))).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(c.mapObjectFunc), builder.WithPredicates(predicate.Funcs{
+			CreateFunc: func(e event.CreateEvent) bool {
+				klog.V(2).Infof("enqueue SAA reconcile for pod create event %s/%s", e.Object.GetNamespace(), e.Object.GetName())
+				return c.filterObject(ctx, e.Object)
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				klog.V(2).Infof("enqueue SAA reconcile for pod delete event %s/%s", e.Object.GetNamespace(), e.Object.GetName())
+				return c.filterObject(ctx, e.Object)
+			},
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				oldPod, ok1 := e.ObjectOld.(*corev1.Pod)
+				newPod, ok2 := e.ObjectNew.(*corev1.Pod)
+				if !ok1 || !ok2 {
+					return false
+				}
+				// Only allow NodeName transition from empty to non-empty, or ServiceAccountName changes
+				if oldPod.Spec.NodeName == "" && newPod.Spec.NodeName != "" {
+					return c.filterObject(ctx, newPod)
+				}
+				if oldPod.Spec.ServiceAccountName != newPod.Spec.ServiceAccountName {
+					return c.filterObject(ctx, newPod)
+				}
+				return false
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				klog.V(2).Infof("enqueue SAA reconcile for pod generic event %s/%s", e.Object.GetNamespace(), e.Object.GetName())
+				return false
+			},
+		})).
 		Complete(c)
 }
 
@@ -346,10 +416,13 @@ func subtractSlice(source, subTarget []string) []string {
 
 func (c *Controller) send2Edge(acc *policyv1alpha1.ServiceAccountAccess, targets []string, opr string) {
 	sendObj := acc.DeepCopy()
+	klog.V(3).Infof("[SAA send2Edge] begin: acc=%s/%s rv=%s targets=%d op=%s", sendObj.Namespace, sendObj.Name, sendObj.ResourceVersion, len(targets), opr)
+	var sent, buildErr, sendErr int
 	for _, node := range targets {
 		resource, err := messagelayer.BuildResource(node, sendObj.Namespace, model.ResourceTypeSaAccess, sendObj.Name)
 		if err != nil {
-			klog.Warningf("built message resource failed with error: %s", err)
+			buildErr++
+			klog.Warningf("[SAA send2Edge] build resource failed: node=%s acc=%s/%s err=%v", node, sendObj.Namespace, sendObj.Name, err)
 			continue
 		}
 		// filter out the node list data
@@ -358,10 +431,13 @@ func (c *Controller) send2Edge(acc *policyv1alpha1.ServiceAccountAccess, targets
 			SetResourceVersion(sendObj.ResourceVersion).
 			FillBody(sendObj).BuildRouter(modules.PolicyControllerModuleName, constants.GroupResource, resource, opr)
 		if err := c.MessageLayer.Send(*msg); err != nil {
-			klog.Warningf("send message %s failed with error: %s", resource, err)
+			sendErr++
+			klog.Warningf("[SAA send2Edge] send failed: resource=%s err=%v", resource, err)
 			continue
 		}
+		sent++
 	}
+	klog.V(3).Infof("[SAA send2Edge] done: acc=%s/%s total=%d sent=%d buildErr=%d sendErr=%d", sendObj.Namespace, sendObj.Name, len(targets), sent, buildErr, sendErr)
 }
 
 func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceAccountAccess) (controllerruntime.Result, error) {
@@ -447,6 +523,52 @@ func (c *Controller) syncRules(ctx context.Context, acc *policyv1alpha1.ServiceA
 		}
 	}
 	return controllerruntime.Result{}, nil
+}
+
+// StartPeriodicResync periodically re-syncs all ServiceAccountAccess resources
+// to ensure eventual consistency across edge nodes even without object updates.
+// It enumerates all ServiceAccountAccess objects and invokes the same reconcile
+// logic used by event-driven reconciliation.
+func (c *Controller) StartPeriodicResync(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		klog.V(2).Infof("[SAA PeriodicResync] disabled (interval<=0)")
+		return
+	}
+	klog.V(2).Infof("[SAA PeriodicResync] start with interval=%s", interval.String())
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				klog.V(2).Infof("[SAA PeriodicResync] context done, stop")
+				return
+			case <-ticker.C:
+				tickStart := time.Now()
+				var accList = &policyv1alpha1.ServiceAccountAccessList{}
+				if err := c.Client.List(ctx, accList); err != nil {
+					klog.Errorf("[SAA PeriodicResync] list serviceaccountaccess failed: %v", err)
+					continue
+				}
+				processed, skipped, failed := 0, 0, 0
+				for i := range accList.Items {
+					acc := &accList.Items[i]
+					// ignore deleting objects
+					if !acc.GetDeletionTimestamp().IsZero() {
+						skipped++
+						continue
+					}
+					if _, err := c.syncRules(ctx, acc); err != nil {
+						failed++
+						klog.V(4).Infof("[SAA PeriodicResync] sync %s/%s failed: %v", acc.Namespace, acc.Name, err)
+						continue
+					}
+					processed++
+				}
+				klog.V(2).Infof("[SAA PeriodicResync] tick done: total=%d processed=%d skipped=%d failed=%d cost=%s", len(accList.Items), processed, skipped, failed, time.Since(tickStart))
+			}
+		}
+	}()
 }
 
 func equalAccessBindingSlice(a, b interface{}) bool {

--- a/cloud/pkg/policycontroller/policycontroller.go
+++ b/cloud/pkg/policycontroller/policycontroller.go
@@ -3,6 +3,8 @@ package policycontroller
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -10,6 +12,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	controllerruntime "sigs.k8s.io/controller-runtime"
+	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	controllerruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -18,6 +21,7 @@ import (
 	beehiveContext "github.com/kubeedge/beehive/pkg/core/context"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/messagelayer"
 	"github.com/kubeedge/kubeedge/cloud/pkg/common/modules"
+	policypkg "github.com/kubeedge/kubeedge/cloud/pkg/policycontroller/config"
 	pm "github.com/kubeedge/kubeedge/cloud/pkg/policycontroller/manager"
 	kefeatures "github.com/kubeedge/kubeedge/pkg/features"
 )
@@ -38,6 +42,9 @@ func init() {
 }
 
 func NewAccessRoleControllerManager(ctx context.Context, kubeCfg *rest.Config) (manager.Manager, error) {
+	// Initialize controller-runtime logging to klog to ensure logs are visible
+	crlog.SetLogger(klog.FromContext(ctx))
+
 	controllerManager, err := controllerruntime.NewManager(kubeCfg, controllerruntime.Options{
 		Scheme: accessScheme,
 		Metrics: controllerruntimemetrics.Options{
@@ -70,7 +77,20 @@ func setupControllers(ctx context.Context, mgr manager.Manager) error {
 	if err := pc.SetupWithManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to setup nodegroup controller, %v", err)
 	}
+	// Start periodic resync to ensure eventual consistency on edge nodes.
+	// Default interval: 2 minutes. In production, consider making it configurable.
+	// interval from cloudcore config if available; fallback to 2m
+	interval := getResyncIntervalFromConfig()
+	pc.StartPeriodicResync(ctx, interval)
 	return nil
+}
+
+// getResyncIntervalFromConfig reads periodic resync interval from cloudcore config if present.
+func getResyncIntervalFromConfig() time.Duration {
+	if policypkg.Config.PolicyController.PeriodicResyncInterval.Duration > 0 {
+		return policypkg.Config.PolicyController.PeriodicResyncInterval.Duration
+	}
+	return 2 * time.Minute
 }
 
 func Register(kubeCfg *rest.Config) {
@@ -101,6 +121,37 @@ func (pc *policyController) Enable() bool {
 
 // Start controller
 func (pc *policyController) Start() {
+	// start sync-request receiver before controller manager blocking start
+	go func(ctx context.Context, mgr manager.Manager) {
+		ml := messagelayer.PolicyControllerMessageLayer()
+		// build a lightweight controller for handling sync requests
+		acc := &pm.Controller{Client: mgr.GetClient(), MessageLayer: messagelayer.PolicyControllerMessageLayer()}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			msg, err := ml.Receive()
+			if err != nil {
+				klog.V(2).Infof("[SAA SyncReceiver] receive error: %v", err)
+				continue
+			}
+			parts := strings.Split(msg.GetResource(), "/")
+			if len(parts) < 4 {
+				klog.V(2).Infof("[SAA SyncReceiver] skip invalid resource: %s", msg.GetResource())
+				continue
+			}
+			if parts[0] != "node" || parts[3] != "serviceaccountaccess" || msg.GetOperation() != "query" {
+				klog.V(2).Infof("[SAA SyncReceiver] skip non-sync message: resource=%s op=%s", msg.GetResource(), msg.GetOperation())
+				continue
+			}
+			nodeName := parts[1]
+			namespace := parts[2]
+			acc.HandleSyncRequest(ctx, nodeName, namespace)
+		}
+	}(pc.ctx, pc.manager)
+
 	// mgr.Start will block until the manager has stopped
 	if err := pc.manager.Start(pc.ctx); err != nil {
 		klog.Fatalf("failed to start controller manager, %v", err)

--- a/docs/proposals/serviceaccountaccess-sync-enhancement.md
+++ b/docs/proposals/serviceaccountaccess-sync-enhancement.md
@@ -1,0 +1,288 @@
+# ServiceAccountAccess 同步机制增强
+
+## 摘要
+
+本文档描述了 KubeEdge 中 ServiceAccountAccess (SAA) 资源同步机制存在的问题以及相应的改进方案。通过实现云端周期对账、边端重连主动同步，以及事件驱动增强（Pod/Node 监听），解决了 SAA 对象在边缘节点间不一致和延迟同步的问题。
+
+## 问题分析
+
+### 原始问题描述
+
+用户反馈遇到多次 SAA 同步不一致的情况：
+- 云端存在 ServiceAccountAccess 对象
+- 边缘节点数据库中，有的节点有 SAA 记录，有的节点没有
+- 手动编辑云端的 SAA 对象后，边缘节点才同步到数据
+
+### 根本原因分析
+
+经过深入分析，发现以下根本原因：
+
+#### 1. 消息传递不可靠
+- **问题**：KubeEdge 的消息传递机制不保证离线期间的可靠投递
+- **影响**：边缘节点离线期间，云端发送的 SAA 消息可能丢失
+- **表现**：节点重新上线后，缺少离线期间创建的 SAA 数据
+
+#### 2. 目标节点计算时机问题
+- **问题**：SAA 创建时，目标边缘节点可能还未就绪或标签不完整
+- **影响**：初始 reconcile 时无法正确识别所有目标节点
+- **表现**：部分节点被遗漏，导致 SAA 数据不一致
+
+#### 3. 边端重连缺乏主动同步
+- **问题**：边缘节点重连后，仅依赖云端的被动推送
+- **影响**：如果云端没有变化，边端无法主动补齐缺失的 SAA 数据
+- **表现**：数据库丢失或数据不一致时，无法自动恢复
+
+#### 4. 消息路由和确认机制问题
+- **问题**：SAA 消息在 CloudHub 中的 ACK 机制配置不当
+- **影响**：消息可能因 key 生成失败而被丢弃
+- **表现**：云端显示发送成功，但边端实际未收到
+
+## 改进方案
+
+### 方案 A：云端周期对账（Periodic Resync）
+
+#### 设计思路
+在 PolicyController 中实现周期性的 SAA 对象重新评估和同步，确保最终一致性。
+
+#### 实现细节
+```go
+func (c *Controller) StartPeriodicResync(ctx context.Context, interval time.Duration) {
+    if interval <= 0 {
+        klog.V(2).Infof("[SAA PeriodicResync] disabled (interval<=0)")
+        return
+    }
+    
+    ticker := time.NewTicker(interval)
+    go func() {
+        defer ticker.Stop()
+        for {
+            select {
+            case <-ctx.Done():
+                return
+            case <-ticker.C:
+                // 列出所有 SAA 对象并重新同步
+                var accList = &policyv1alpha1.ServiceAccountAccessList{}
+                if err := c.Client.List(ctx, accList); err != nil {
+                    continue
+                }
+                
+                for i := range accList.Items {
+                    acc := &accList.Items[i]
+                    if !acc.GetDeletionTimestamp().IsZero() {
+                        continue
+                    }
+                    c.syncRules(ctx, acc)
+                }
+            }
+        }
+    }()
+}
+```
+
+#### 配置化
+- 通过 CloudCore 配置 `modules.policyController.periodicResyncInterval` 控制同步间隔
+- 默认值：2分钟
+- 支持 Helm Chart 配置
+
+### 方案 B：边端重连主动同步（On-Connect Active Sync）
+
+#### 设计思路
+边缘节点重连成功后，主动向云端请求 SAA 数据同步，补齐可能缺失的数据。
+
+#### 实现流程
+1. **EdgeHub 连接成功** → 发送 `node/connection` 消息到 MetaManager
+2. **MetaManager 接收连接事件** → 调用 `onCloudConnected()`
+3. **主动请求同步** → 发送 `QueryOperation` 消息到云端
+4. **云端处理请求** → PolicyController 接收并调用 `HandleSyncRequest`
+5. **定向下发数据** → 根据节点和命名空间过滤，发送相关 SAA 对象
+
+#### 关键代码
+```go
+func (m *metaManager) onCloudConnected() {
+    if !connect.IsConnected() {
+        return
+    }
+    
+    // 构建查询消息，请求所有命名空间的完整同步
+    resource := fmt.Sprintf("%s/%s", "_", model.ResourceTypeSaAccess)
+    msg := model.NewMessage("").
+        BuildRouter(modules.MetaManagerModuleName, GroupResource, resource, model.QueryOperation)
+    
+    sendToCloud(msg)
+}
+```
+
+### 消息路由优化
+
+#### 1. 资源路径标准化
+- **问题**：边端发送 `node/<nodeID>/_/serviceaccountaccess` 被误识别为 node 资源
+- **解决**：边端发送 `_/serviceaccountaccess`，CloudHub 自动补全 `node/<nodeID>/` 前缀
+
+#### 2. 消息组路由
+- **问题**：SAA 消息使用 `edgecontroller` 组，MetaManager 无法处理
+- **解决**：改为使用 `resource` 组，确保 MetaManager 能正确接收和处理
+
+#### 3. ACK 机制优化
+- **问题**：SAA 消息在 CloudHub 中因 key 生成失败被丢弃
+- **解决**：将 SAA 标记为 `NO-ACK` 资源，绕过 ACK 机制
+
+## 技术实现
+
+### 新增配置结构
+
+```go
+type PolicyController struct {
+    Enable bool `json:"enable"`
+    PeriodicResyncInterval string `json:"periodicResyncInterval,omitempty"`
+}
+```
+
+### 消息处理流程
+
+```
+RBAC/Pod 事件 → PolicyController → 计算目标节点并下发 SAA
+EdgeCore 重连 → EdgeHub → MetaManager → 发送同步请求 → CloudHub → PolicyController → 处理请求 → 下发 SAA 对象 → EdgeCore → MetaManager → 落库
+周期对账 → PolicyController → 全量复核并修补
+```
+
+### 日志级别设计
+
+- **V2**：关键操作概要（连接、同步开始/完成、错误）
+- **V3**：操作统计信息（发送数量、成功/失败计数）
+- **V4**：详细操作信息（目标节点、资源详情）
+- **V5**：调试信息（消息内容、内部状态）
+
+## 部署配置
+
+### Helm Chart 配置
+
+```yaml
+cloudCore:
+  modules:
+    policyController:
+      enable: true
+      periodicResyncInterval: 2m
+  featureGates:
+    requireAuthorization: true
+```
+
+### 默认配置
+
+```yaml
+modules:
+  policyController:
+    enable: true
+    periodicResyncInterval: "2m"
+```
+
+## 测试验证
+
+### 功能测试
+1. **周期同步测试**：验证云端按配置间隔自动同步 SAA 对象
+2. **重连同步测试**：验证边缘节点重连后主动请求并接收 SAA 数据
+3. **数据一致性测试**：验证多个边缘节点的 SAA 数据最终一致
+
+### 性能测试
+1. **同步延迟测试**：测量从 SAA 创建到边端同步的延迟
+2. **资源消耗测试**：监控周期同步对系统资源的影响
+3. **并发处理测试**：验证多个边缘节点同时重连时的处理能力
+
+### 故障恢复测试
+1. **网络中断测试**：模拟网络中断和恢复场景
+2. **数据库丢失测试**：验证边端数据库丢失后的自动恢复
+3. **云端重启测试**：验证云端重启后同步机制的恢复
+
+## 兼容性说明
+
+### 向后兼容
+- 新增功能默认启用，不影响现有部署
+- 配置项有合理的默认值，无需强制配置
+- 消息格式保持兼容，不影响现有消息流
+
+### 升级路径
+1. 更新 CloudCore 镜像
+2. 可选：调整 `periodicResyncInterval` 配置
+3. 重启 CloudCore 使配置生效
+4. 边端无需重启，重连时自动使用新机制
+
+## 监控和运维
+
+### 关键指标
+- SAA 同步成功率
+- 同步延迟分布
+- 周期同步执行频率
+- 边端重连同步请求数量
+
+### 日志关键字
+- `[SAA PeriodicResync]`：周期同步相关日志
+- `[SAA SyncRequest]`：边端同步请求处理日志
+- `[SAA send2Edge]`：SAA 对象下发日志
+
+### 故障排查
+1. **同步失败**：检查 PolicyController 日志中的错误信息
+2. **数据不一致**：查看周期同步和重连同步的执行情况
+3. **性能问题**：调整 `periodicResyncInterval` 配置
+
+## 总结
+
+通过实现云端周期对账和边端重连主动同步，我们解决了 ServiceAccountAccess 在边缘节点间同步不一致的根本问题。这一改进：
+
+1. **提高了数据一致性**：通过周期对账确保最终一致性
+2. **增强了故障恢复能力**：边端重连后主动补齐缺失数据
+3. **改善了运维体验**：配置化同步间隔，详细的日志记录
+4. **保持了系统稳定性**：无破坏性变更，向后兼容
+
+这些改进使得 KubeEdge 的 RBAC 授权机制更加可靠和健壮，为边缘计算环境中的安全访问控制提供了更好的保障。
+
+---
+
+## 事件驱动增强（与当前实现对齐）
+
+### 设计思路
+- 除周期对账与重连主动同步外，补充事件驱动以尽可能“实时”地推动 SAA 计算与下发：
+  - 监听 Pod 的创建/删除事件；
+  - 监听 Pod 的关键更新事件：当 `spec.nodeName` 从空变为非空（完成调度）或 `spec.serviceAccountName` 发生变化；
+  - 监听 Node 的创建与标签变化：当节点成为“边缘节点”时（打上 `node-role.kubernetes.io/edge=edge`），主动对该节点发起一次同步。
+
+### 实现细节（概要）
+
+1) Pod 监听与过滤
+
+- 只放行以下事件进入控制器队列：
+  - Create：针对使用了某 SA 的 Pod；
+  - Delete：针对使用了某 SA 的 Pod；
+  - Update：仅当 `nodeName: "" -> 非空` 或 `serviceAccountName` 变更；
+- 事件通过 `filterObject` 再次过滤：仅当 Pod 绑定了边缘节点（`nodeName` 非空且对应节点具备 `node-role.kubernetes.io/edge=edge` 标签）且指定了 `serviceAccountName` 时才生效；
+- 由于很多 Pod 在“创建时”尚未拿到 `nodeName`，Create 事件可能被过滤；一旦调度完成，`nodeName` 赋值会触发上述“关键更新”从而进入同步。
+
+2) 同步与下发
+
+- Reconcile/HandleSyncRequest 计算目标边缘节点集合（同命名空间、使用该 SA 的所有 Pod 所在边缘节点），进行差量下发：
+  - Insert：只对新增节点发送；
+  - Update：对象规格变更时对所有目标节点发送；
+  - Delete：对不再匹配的节点发送；
+- 下发消息在 CloudHub 中标记为 NO-ACK，以避免 ACK key 问题导致丢弃；丢投递由“重连主动同步 + 周期对账”兜底。
+
+### 关键注意事项
+
+- Pod Create 大概率没有 `nodeName`，会被 `filterObject` 过滤；依赖“Pod 调度时的关键 Update 事件（`nodeName` 从空到非空）”补齐触发。
+- 仅“删除节点”场景下，当前规格不变时仅会向边缘下发删除消息，`ServiceAccountAccess.status.nodeList` 不一定立刻回写剔除该节点（可通过增强状态写回逻辑或更短的周期对账弥补）。
+- 仅统计带有 `node-role.kubernetes.io/edge=edge` 标签的节点作为目标边缘节点；未打标签的节点不会计入。
+
+### 建议配置
+
+- 打开 `requireAuthorization` 特性门控；
+- 合理设置 `modules.policyController.periodicResyncInterval`（建议 1-2 分钟，或按业务调优）；
+
+### RBAC 事件（Role/RoleBinding/ClusterRole/ClusterRoleBinding/ServiceAccount）
+
+- 监听对象：`ClusterRoleBinding`、`RoleBinding`、`ClusterRole`、`Role`、`ServiceAccount`。
+- 匹配逻辑：
+  - 通过 `filterResource` 与 `mapRolesFunc`，将 RBAC 对象变化映射到与其有关联的 `ServiceAccountAccess` 上：
+    - 对于 `RoleBinding/ClusterRoleBinding`：匹配 `subjects` 是否包含目标 `ServiceAccount`；
+    - 对于 `Role/ClusterRole`：反查所有绑定到它们的 `RoleBinding/ClusterRoleBinding`，再基于 `subjects` 判断是否影响目标 `ServiceAccount`；
+  - 对于 `ServiceAccount`：使用 `mapObjectFunc` 将 SA 自身变化映射到同命名空间下引用该 SA 的 `ServiceAccountAccess`。
+- 触发效果：
+  - 一旦 RBAC 规则/引用发生变更，控制器会将相关的 `ServiceAccountAccess` 入队，进入 `syncRules`，重新汇总有效 `Rules` 并对边缘节点差量下发（Update/Insert/Delete）。
+- 作用：
+  - 确保授权策略更新能快速反映到边缘节点，避免仅靠周期对账带来的延迟。

--- a/edge/pkg/edged/edged.go
+++ b/edge/pkg/edged/edged.go
@@ -359,7 +359,7 @@ func (e *edged) syncPod(podCfg *config.PodConfig) {
 				beehiveContext.SendResp(*resp)
 			}
 		default:
-			klog.Errorf("resType is not pod or configmap or secret or volume: resType is %s", resType)
+			klog.Infof("resType is not pod or configmap or secret or volume: resType is %s", resType)
 			continue
 		}
 	}

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -144,6 +144,11 @@ func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 			messagepkg.ResourceTypeNodeConnection, messagepkg.OperationNodeConnection).FillBody(content)
 		beehiveContext.SendToGroup(group, *message)
 	}
+	// Notify MetaManager to trigger initial sync when connected
+	if isConnected {
+		syncMsg := model.NewMessage("").BuildRouter(modules.EdgeHubModuleName, modules.MetaGroup, messagepkg.ResourceTypeNodeConnection, messagepkg.OperationNodeConnection).FillBody(content)
+		beehiveContext.Send(modules.MetaManagerModuleName, *syncMsg)
+	}
 }
 
 func (eh *EdgeHub) ifRotationDone() {

--- a/edge/pkg/metamanager/client/serviceaccount.go
+++ b/edge/pkg/metamanager/client/serviceaccount.go
@@ -228,24 +228,38 @@ func (s *serviceAccount) Get(name string) (*corev1.ServiceAccount, error) {
 
 func CheckTokenExist(token string) bool {
 	if token == "" {
+		klog.V(4).Infof("[Auth] CheckTokenExist: empty token")
 		return false
 	}
 	metas, err := dao.QueryMeta("type", model.ResourceTypeServiceAccountToken)
 	if err != nil {
-		klog.Errorf("query meta %s failed: %v", model.ResourceTypeServiceAccountToken, err)
+		klog.Errorf("[Auth] CheckTokenExist: query meta %s failed: %v", model.ResourceTypeServiceAccountToken, err)
 		return false
 	}
 
-	for _, v := range *metas {
+	klog.Infof("[Auth] CheckTokenExist: checking token (first 30 chars: %s...)", truncateToken(token, 30))
+	klog.Infof("[Auth] CheckTokenExist: found %d serviceaccounttoken records in DB", len(*metas))
+
+	for i, v := range *metas {
 		var tokenRequest authenticationv1.TokenRequest
 		err = json.Unmarshal([]byte(v), &tokenRequest)
 		if err != nil {
-			klog.Errorf("unmarshal resource %s token request failed: %v", model.ResourceTypeServiceAccountToken, err)
-			return false
+			klog.Errorf("[Auth] CheckTokenExist: unmarshal record %d failed: %v", i, err)
+			continue
 		}
 		if tokenRequest.Status.Token == token {
 			return true
 		}
 	}
+
+	klog.Errorf("[Auth] CheckTokenExist: ✗ TOKEN NOT FOUND! Checked %d records, none matched. Request token: %s...",
+		len(*metas), truncateToken(token, 30))
 	return false
+}
+
+func truncateToken(token string, maxLen int) string {
+	if len(token) <= maxLen {
+		return token
+	}
+	return token[:maxLen]
 }

--- a/edge/pkg/metamanager/dao/meta.go
+++ b/edge/pkg/metamanager/dao/meta.go
@@ -69,7 +69,9 @@ func UpdateMeta(meta *Meta) error {
 // InsertOrUpdate insert or update meta
 func InsertOrUpdate(meta *Meta) error {
 	_, err := dbm.DBAccess.Raw("INSERT OR REPLACE INTO meta (key, type, value) VALUES (?,?,?)", meta.Key, meta.Type, meta.Value).Exec() // will update all field
-	klog.V(4).Infof("Update result %v", err)
+	if err != nil {
+		klog.Errorf("insert or update meta failed, key=%s type=%s value=%s, err=%v", meta.Key, meta.Type, meta.Value, err)
+	}
 	return err
 }
 

--- a/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
+++ b/manifests/charts/cloudcore/templates/configmap_cloudcore.yaml
@@ -50,6 +50,9 @@ data:
         tunnelPort: 10004
       dynamicController:
         enable: {{ .Values.cloudCore.modules.dynamicController.enable }}
+      policyController:
+        enable: {{ .Values.cloudCore.modules.policyController.enable }}
+        periodicResyncInterval: {{ .Values.cloudCore.modules.policyController.periodicResyncInterval }}
       router:
         enable: {{ .Values.cloudCore.modules.router.enable }}
       iptablesManager:

--- a/manifests/charts/cloudcore/values.yaml
+++ b/manifests/charts/cloudcore/values.yaml
@@ -57,7 +57,10 @@ cloudCore:
     cloudStream:
       enable: true
     dynamicController:
-      enable: false
+      enable: true
+    policyController:
+      enable: true
+      periodicResyncInterval: 2m
     router:
       enable: false
     taskManager:

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"path"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -146,6 +147,10 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 			IptablesManager: &IptablesManager{
 				Enable: true,
 				Mode:   InternalMode,
+			},
+			PolicyController: &PolicyController{
+				Enable:                 true,
+				PeriodicResyncInterval: metav1.Duration{Duration: 2 * time.Minute},
 			},
 		},
 	}
@@ -299,6 +304,10 @@ func NewMinCloudCoreConfig() *CloudCoreConfig {
 			IptablesManager: &IptablesManager{
 				Enable: true,
 				Mode:   InternalMode,
+			},
+			PolicyController: &PolicyController{
+				Enable:                 true,
+				PeriodicResyncInterval: metav1.Duration{Duration: 2 * time.Minute},
 			},
 		},
 	}

--- a/staging/src/github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/staging/src/github.com/kubeedge/api/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -100,6 +100,8 @@ type Modules struct {
 	Router *Router `json:"router,omitempty"`
 	// IptablesManager indicates iptables module config
 	IptablesManager *IptablesManager `json:"iptablesManager,omitempty"`
+	// PolicyController indicates policycontroller module config
+	PolicyController *PolicyController `json:"policyController,omitempty"`
 }
 
 // CloudHub indicates the config of CloudHub module.
@@ -536,6 +538,16 @@ type Router struct {
 	Address     string `json:"address,omitempty"`
 	Port        uint32 `json:"port,omitempty"`
 	RestTimeout uint32 `json:"restTimeout,omitempty"`
+}
+
+// PolicyController indicates the policycontroller module config
+type PolicyController struct {
+	// Enable indicates whether policycontroller is enabled
+	// default true when feature gate RequireAuthorization enabled
+	Enable bool `json:"enable"`
+	// PeriodicResyncInterval sets the interval of periodic reconcile for serviceaccountaccess
+	// default 2m
+	PeriodicResyncInterval metav1.Duration `json:"periodicResyncInterval,omitempty"`
 }
 
 // IptablesManager indicates the config of Iptables


### PR DESCRIPTION
* 边端重连主动同步 SAA + 云端周期对账与可配置

- 云端
  - policycontroller: 新增 StartPeriodicResync，按 CloudCore 配置 modules.policyController.periodicResyncInterval（默认 2m）定期对账并补发
  - 新增同步请求接收循环：处理 edge 侧 Query node/<node>/<ns>/serviceaccountaccess，调用 HandleSyncRequest 定向下发
  - send2Edge 目标 group 改为资源路由（resource），并补充必要日志（V2 概要、V3 发送统计、V4 目标节点）
  - cloudhub/dispatcher：上行自动补 node/<node>/ 前缀；将 serviceaccountaccess 路由到 policycontroller；noAckRequired 支持 SAA
  - cloudhub/authorization：将 SAA 识别为 kubeedge 非资源，放行自定义同步消息
- 边端
  - EdgeHub 重连后向 MetaManager 发送 node/connection 事件
  - MetaManager onCloudConnected 发送 “_/serviceaccountaccess” Query（避免被误识别为 node 资源）
  - 继续复用 handleMessage Insert/Update/Delete/Response 路径落库
- Helm
  - chart 增加 modules.policyController（enable、periodicResyncInterval）并渲染至 cloudcore.yaml
- 日志与健壮性
  - 梳理日志级别（V2 概要、V3 统计、V4 细节、V5 冗余），便于排查
  - 修复零散问题与 lints（去除多余字符等）

* add doc

(cherry picked from commit 6368ccc82214ce56b3ecae2ecedddc80308fb512)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
